### PR TITLE
Chapter 2 Lock Vite Version #296

### DIFF
--- a/docs/react-app.adoc
+++ b/docs/react-app.adoc
@@ -10,7 +10,7 @@ With the sandbox running, open a new terminal tab/window and run the following c
 
 [source,Terminal]
 ----
-npm create vite@latest react-enonic -- --template react-ts
+npm create vite@6.1.1 react-enonic -- --template react-ts
 ----
 
 This will create a React app and place it in a folder called `react-enonic/`.


### PR DESCRIPTION
As of now there is no version lock for Vite, as a result of this there is lack of control what version React and other dependencies end up in.

![image](https://github.com/user-attachments/assets/25e72324-9fb5-4cfb-9c44-aa2df4c83876)

Suggested solution, at a version lock for Vite (Latest known compatible "create vite@6.1.1 ").